### PR TITLE
Use iterators

### DIFF
--- a/src/aberth.rs
+++ b/src/aberth.rs
@@ -36,11 +36,11 @@ const TWO_PI: f64 = std::f64::consts::TAU;
 /// assert_approx_eq!(px, 18250.0);
 /// ```
 pub fn horner_eval_f(coeffs: &[f64], zval: f64) -> f64 {
-    let mut res = coeffs[0];
-    for coeff in coeffs.iter().skip(1) {
-        res = res * zval + coeff;
-    }
-    res
+    coeffs
+        .iter()
+        .copied()
+        .reduce(|res, coeff| res * zval + coeff)
+        .unwrap()
 }
 
 /// Horner evalution (complex)
@@ -73,12 +73,11 @@ pub fn horner_eval_f(coeffs: &[f64], zval: f64) -> f64 {
 /// assert_approx_eq!(px.im, 9120.0);
 /// ```
 pub fn horner_eval_c(coeffs: &[f64], zval: &Complex<f64>) -> Complex<f64> {
-    let mut res = Complex::<f64>::new(coeffs[0], 0.0);
-    for coeff in coeffs.iter().skip(1) {
-        res *= zval;
-        res += coeff;
-    }
-    res
+    coeffs
+        .iter()
+        .map(|coeff| Complex::<f64>::new(*coeff, 0.0))
+        .reduce(|res, coeff| res * zval + coeff)
+        .unwrap()
 }
 
 /// Initial guess for Aberth's method

--- a/src/robin.rs
+++ b/src/robin.rs
@@ -63,15 +63,15 @@ impl Robin {
     /// 
     /// The `new` function is returning an instance of the struct that it is defined in.
     pub fn new(num_parts: usize) -> Self {
-        let mut cycle = Vec::new();
-        for k in 0..num_parts {
-            cycle.push(SlNode {
+        let mut cycle = (0..num_parts)
+            .into_iter()
+            .map(|k| SlNode {
                 next: None,
                 data: k,
-            });
-        }
+            })
+            .collect();
         let mut sl2 = &mut cycle[num_parts - 1];
-        for sl1 in &mut cycle {
+        for sl1 in cycle {
             sl2.next = Some(Box::new(sl1.clone()));
             sl2 = sl2.next.as_mut().unwrap();
         }


### PR DESCRIPTION
Using iterators allow the compiler to prealocate the exact memory required on the heap (for Vec and similar). Sometimes also makes the code ez to undertand.