### PR TITLE
Improve horner

### DIFF
--- a/src/aberth.rs
+++ b/src/aberth.rs
@@ -1,84 +1,11 @@
 #![allow(non_snake_case)]
 
+use super::horner::{horner_eval_c, horner_eval_f};
 use super::Options;
 use num::Complex;
 // use lds_rs::lds::Circle;
 
 const TWO_PI: f64 = std::f64::consts::TAU;
-
-/// Horner evalution (float)
-/// 
-/// The `horner_eval_f` function in Rust implements the Horner's method for evaluating a polynomial with
-/// given coefficients at a specific value.
-/// 
-/// Arguments:
-/// 
-/// * `coeffs`: A vector of floating-point coefficients representing a polynomial. The coefficients are
-/// ordered from highest degree to lowest degree. For example, the polynomial 10x^8 + 34x^7 + 75x^6 +
-/// 94x^5 + 150x^4 + 94x^
-/// * `zval`: The `zval` parameter in the `horner_eval_f` function represents the value at which the
-/// polynomial is evaluated. It is of type `f64`, which means it is a floating-point number.
-/// 
-/// Returns:
-/// 
-/// The function `horner_eval_f` returns a `f64` value, which is the result of evaluating the polynomial
-/// with the given coefficients at the specified value `zval`.
-///
-/// # Examples:
-///
-/// ```
-/// use bairstow::aberth::horner_eval_f;
-/// use approx_eq::assert_approx_eq;
-///
-/// let coeffs = vec![10.0, 34.0, 75.0, 94.0, 150.0, 94.0, 75.0, 34.0, 10.0];
-/// let px = horner_eval_f(&coeffs, 2.0);
-///
-/// assert_approx_eq!(px, 18250.0);
-/// ```
-pub fn horner_eval_f(coeffs: &[f64], zval: f64) -> f64 {
-    coeffs
-        .iter()
-        .copied()
-        .reduce(|res, coeff| res * zval + coeff)
-        .unwrap()
-}
-
-/// Horner evalution (complex)
-/// 
-/// The `horner_eval_c` function in Rust implements the Horner evaluation method for complex
-/// polynomials.
-/// 
-/// Arguments:
-/// 
-/// * `coeffs`: A vector of coefficients representing a polynomial. The coefficients are in descending
-/// order of degree. For example, the polynomial 10x^8 + 34x^7 + 75x^6 + 94x^5 + 150x^4 + 94x^3 + 75
-/// * `zval`: The `zval` parameter is a complex number that represents the value at which the polynomial
-/// is evaluated.
-/// 
-/// Returns:
-/// 
-/// The function `horner_eval_c` returns a complex number of type `Complex<f64>`.
-///
-/// # Examples:
-///
-/// ```
-/// use bairstow::aberth::horner_eval_c;
-/// use approx_eq::assert_approx_eq;
-/// use num::Complex;
-///
-/// let coeffs = vec![10.0, 34.0, 75.0, 94.0, 150.0, 94.0, 75.0, 34.0, 10.0];
-/// let px = horner_eval_c(&coeffs, &Complex::new(1.0, 2.0));
-///
-/// assert_approx_eq!(px.re, 6080.0);
-/// assert_approx_eq!(px.im, 9120.0);
-/// ```
-pub fn horner_eval_c(coeffs: &[f64], zval: &Complex<f64>) -> Complex<f64> {
-    coeffs
-        .iter()
-        .map(|coeff| Complex::<f64>::new(*coeff, 0.0))
-        .reduce(|res, coeff| res * zval + coeff)
-        .unwrap()
-}
 
 /// Initial guess for Aberth's method
 /// 

--- a/src/horner.rs
+++ b/src/horner.rs
@@ -1,0 +1,152 @@
+use num::Complex;
+
+use crate::Vector2;
+
+/// Horner evalution (float)
+///
+/// The `horner_eval_f` function in Rust implements the Horner's method for evaluating a polynomial with
+/// given coefficients at a specific value.
+///
+/// Arguments:
+///
+/// * `coeffs`: A vector of floating-point coefficients representing a polynomial. The coefficients are
+/// ordered from highest degree to lowest degree. For example, the polynomial 10x^8 + 34x^7 + 75x^6 +
+/// 94x^5 + 150x^4 + 94x^
+/// * `zval`: The `zval` parameter in the `horner_eval_f` function represents the value at which the
+/// polynomial is evaluated. It is of type `f64`, which means it is a floating-point number.
+///
+/// Returns:
+///
+/// The function `horner_eval_f` returns a `f64` value, which is the result of evaluating the polynomial
+/// with the given coefficients at the specified value `zval`.
+///
+/// # Examples:
+///
+/// ```
+/// use bairstow::horner::horner_eval_f;
+/// use approx_eq::assert_approx_eq;
+///
+/// let coeffs = vec![10.0, 34.0, 75.0, 94.0, 150.0, 94.0, 75.0, 34.0, 10.0];
+/// let px = horner_eval_f(&coeffs, 2.0);
+///
+/// assert_approx_eq!(px, 18250.0);
+/// ```
+pub fn horner_eval_f(coeffs: &[f64], zval: f64) -> f64 {
+    coeffs
+        .iter()
+        .copied()
+        .reduce(|res, coeff| res * zval + coeff)
+        .unwrap()
+}
+
+/// Horner evalution (complex)
+///
+/// The `horner_eval_c` function in Rust implements the Horner evaluation method for complex
+/// polynomials.
+///
+/// Arguments:
+///
+/// * `coeffs`: A vector of coefficients representing a polynomial. The coefficients are in descending
+/// order of degree. For example, the polynomial 10x^8 + 34x^7 + 75x^6 + 94x^5 + 150x^4 + 94x^3 + 75
+/// * `zval`: The `zval` parameter is a complex number that represents the value at which the polynomial
+/// is evaluated.
+///
+/// Returns:
+///
+/// The function `horner_eval_c` returns a complex number of type `Complex<f64>`.
+///
+/// # Examples:
+///
+/// ```
+/// use bairstow::horner::horner_eval_c;
+/// use approx_eq::assert_approx_eq;
+/// use num::Complex;
+///
+/// let coeffs = vec![10.0, 34.0, 75.0, 94.0, 150.0, 94.0, 75.0, 34.0, 10.0];
+/// let px = horner_eval_c(&coeffs, &Complex::new(1.0, 2.0));
+///
+/// assert_approx_eq!(px.re, 6080.0);
+/// assert_approx_eq!(px.im, 9120.0);
+/// ```
+pub fn horner_eval_c(coeffs: &[f64], zval: &Complex<f64>) -> Complex<f64> {
+    coeffs
+        .iter()
+        .map(|coeff| Complex::<f64>::new(*coeff, 0.0))
+        .reduce(|res, coeff| res * zval + coeff)
+        .unwrap()
+}
+
+/// The `horner_eval` function in Rust implements the Horner's method for polynomial evaluation.
+///
+/// Arguments:
+///
+/// * `coeffs`: A mutable slice of f64 values representing the coefficients of a polynomial. The
+/// coefficients are ordered from highest degree to lowest degree.
+/// * `degree`: The `degree` parameter represents the degree of the polynomial. In the given example,
+/// the polynomial has a degree of 8.
+/// * `zval`: The `zval` parameter in the `horner_eval` function represents the value at which the
+/// polynomial is evaluated. It is the value of the independent variable in the polynomial expression.
+///
+/// Returns:
+///
+/// The function `horner_eval` returns a `f64` value, which is the result of evaluating the polynomial
+/// with the given coefficients at the specified value `zval`.
+///
+/// # Examples:
+///
+/// ```
+/// use bairstow::horner::horner_eval;
+/// use approx_eq::assert_approx_eq;
+///
+/// let mut coeffs = vec![10.0, 34.0, 75.0, 94.0, 150.0, 94.0, 75.0, 34.0, 10.0];
+/// let px = horner_eval(&mut coeffs, 8, 2.0);
+///
+/// assert_approx_eq!(px, 18250.0);
+/// assert_approx_eq!(coeffs[3], 460.0);
+/// ```
+#[inline]
+pub fn horner_eval(coeffs: &mut [f64], degree: usize, zval: f64) -> f64 {
+    for idx in 0..degree {
+        coeffs[idx + 1] += coeffs[idx] * zval;
+    }
+    coeffs[degree]
+}
+
+/// The `horner` function implements Horner's evaluation for Bairstow's method in Rust.
+///
+/// Arguments:
+///
+/// * `coeffs`: A mutable slice of f64 values representing the coefficients of the polynomial. The
+/// coefficients are in descending order of degree.
+/// * `degree`: The `degree` parameter represents the degree of the polynomial. It is used to determine
+/// the number of coefficients in the `coeffs` array.
+/// * `vr`: The parameter `vr` is a `Vec2` struct that contains two values, `x_` and `y_`. In the
+/// example, `vr` is initialized with the values `-1.0` and `-2.0`.
+///
+/// Returns:
+///
+/// The function `horner` returns a `Vec2` struct, which contains two `f64` values representing the
+/// results of the Horner evaluation.
+///
+/// # Examples:
+///
+/// ```
+/// use bairstow::horner::horner;
+/// use bairstow::vector2::Vector2;
+/// use approx_eq::assert_approx_eq;
+///
+/// let mut coeffs = vec![10.0, 34.0, 75.0, 94.0, 150.0, 94.0, 75.0, 34.0, 10.0];
+/// let px = horner(&mut coeffs, 8, &Vector2::new(-1.0, -2.0));
+///
+/// assert_approx_eq!(px.x_, 114.0);
+/// assert_approx_eq!(px.y_, 134.0);
+/// assert_approx_eq!(coeffs[3], 15.0);
+/// ```
+pub fn horner(coeffs: &mut [f64], degree: usize, vr: &Vector2<f64>) -> Vector2<f64> {
+    let Vector2 { x_: r, y_: q } = vr;
+    for idx in 0..(degree - 1) {
+        coeffs[idx + 1] += coeffs[idx] * r;
+        coeffs[idx + 2] += coeffs[idx] * q;
+    }
+    Vector2::<f64>::new(coeffs[degree - 1], coeffs[degree])
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 pub mod aberth;
+pub mod horner;
 pub mod matrix2;
 pub mod rootfinding;
 pub mod vector2;
@@ -9,7 +10,7 @@ pub mod vector2;
 pub use crate::aberth::{aberth, aberth_mt, initial_aberth};
 pub use crate::matrix2::Matrix2;
 pub use crate::rootfinding::{
-    horner_eval, initial_autocorr, initial_guess, pbairstow_autocorr, pbairstow_autocorr_mt,
+    initial_autocorr, initial_guess, pbairstow_autocorr, pbairstow_autocorr_mt,
     pbairstow_even, pbairstow_even_mt, Options,
 };
 pub use crate::vector2::Vector2;

--- a/src/rootfinding.rs
+++ b/src/rootfinding.rs
@@ -1,3 +1,4 @@
+use super::horner::{horner, horner_eval};
 use super::{Matrix2, Vector2};
 
 type Vec2 = Vector2<f64>;
@@ -223,81 +224,6 @@ pub fn suppress(vA: &Vec2, vA1: &Vec2, vri: &Vec2, vrj: &Vec2) -> (Vec2, Vec2) {
     vc.y_ -= va.x_ * vp.x_;
     let va1 = m_inverse.mdot(&vc);
     (va, va1)
-}
-
-/// The `horner_eval` function in Rust implements the Horner's method for polynomial evaluation.
-///
-/// Arguments:
-///
-/// * `coeffs`: A mutable slice of f64 values representing the coefficients of a polynomial. The
-/// coefficients are ordered from highest degree to lowest degree.
-/// * `degree`: The `degree` parameter represents the degree of the polynomial. In the given example,
-/// the polynomial has a degree of 8.
-/// * `zval`: The `zval` parameter in the `horner_eval` function represents the value at which the
-/// polynomial is evaluated. It is the value of the independent variable in the polynomial expression.
-///
-/// Returns:
-///
-/// The function `horner_eval` returns a `f64` value, which is the result of evaluating the polynomial
-/// with the given coefficients at the specified value `zval`.
-///
-/// # Examples:
-///
-/// ```
-/// use bairstow::rootfinding::horner_eval;
-/// use approx_eq::assert_approx_eq;
-///
-/// let mut coeffs = vec![10.0, 34.0, 75.0, 94.0, 150.0, 94.0, 75.0, 34.0, 10.0];
-/// let px = horner_eval(&mut coeffs, 8, 2.0);
-///
-/// assert_approx_eq!(px, 18250.0);
-/// assert_approx_eq!(coeffs[3], 460.0);
-/// ```
-#[inline]
-pub fn horner_eval(coeffs: &mut [f64], degree: usize, zval: f64) -> f64 {
-    for idx in 0..degree {
-        coeffs[idx + 1] += coeffs[idx] * zval;
-    }
-    coeffs[degree]
-}
-
-/// The `horner` function implements Horner's evaluation for Bairstow's method in Rust.
-///
-/// Arguments:
-///
-/// * `coeffs`: A mutable slice of f64 values representing the coefficients of the polynomial. The
-/// coefficients are in descending order of degree.
-/// * `degree`: The `degree` parameter represents the degree of the polynomial. It is used to determine
-/// the number of coefficients in the `coeffs` array.
-/// * `vr`: The parameter `vr` is a `Vec2` struct that contains two values, `x_` and `y_`. In the
-/// example, `vr` is initialized with the values `-1.0` and `-2.0`.
-///
-/// Returns:
-///
-/// The function `horner` returns a `Vec2` struct, which contains two `f64` values representing the
-/// results of the Horner evaluation.
-///
-/// # Examples:
-///
-/// ```
-/// use bairstow::rootfinding::horner;
-/// use bairstow::vector2::Vector2;
-/// use approx_eq::assert_approx_eq;
-///
-/// let mut coeffs = vec![10.0, 34.0, 75.0, 94.0, 150.0, 94.0, 75.0, 34.0, 10.0];
-/// let px = horner(&mut coeffs, 8, &Vector2::new(-1.0, -2.0));
-///
-/// assert_approx_eq!(px.x_, 114.0);
-/// assert_approx_eq!(px.y_, 134.0);
-/// assert_approx_eq!(coeffs[3], 15.0);           
-/// ```
-pub fn horner(coeffs: &mut [f64], degree: usize, vr: &Vec2) -> Vec2 {
-    let Vec2 { x_: r, y_: q } = vr;
-    for idx in 0..(degree - 1) {
-        coeffs[idx + 1] += coeffs[idx] * r;
-        coeffs[idx + 2] += coeffs[idx] * q;
-    }
-    Vector2::<f64>::new(coeffs[degree - 1], coeffs[degree])
 }
 
 /// The `initial_guess` function in Rust calculates the initial guesses for the roots of a polynomial

--- a/src/rootfinding.rs
+++ b/src/rootfinding.rs
@@ -1,4 +1,4 @@
-use super::horner::{horner, horner_eval};
+use super::horner::{horner, horner_eval_f};
 use super::{Matrix2, Vector2};
 
 type Vec2 = Vector2<f64>;
@@ -250,8 +250,7 @@ pub fn suppress(vA: &Vec2, vA1: &Vec2, vri: &Vec2, vrj: &Vec2) -> (Vec2, Vec2) {
 pub fn initial_guess(coeffs: &[f64]) -> Vec<Vec2> {
     let mut degree = coeffs.len() - 1;
     let center = -coeffs[1] / (coeffs[0] * degree as f64);
-    let mut pb = coeffs.to_owned();
-    let centroid = horner_eval(&mut pb, degree, center); // ???
+    let centroid = horner_eval_f(coeffs, center); // ???
     let re = centroid.abs().powf(1.0 / (degree as f64));
     degree /= 2;
     degree *= 2; // make even


### PR DESCRIPTION
* Move all horner related functions into a single module.
* Use `horner_eval_f` in `initial_guess` to save a clone.
* Create and use `horner_duble_with_cheese` to avoid a clone in `pbairstow_even` and `pbairstow_autocorr`.

Got some speed boosts:
```
pbairstow_even          time:   [500.07 ns 500.57 ns 501.12 ns]
                        change: [-43.959% -43.825% -43.672%] (p = 0.00 < 0.05)
                        Performance has improved.

pbairstow_autocorr      time:   [1.3696 µs 1.3708 µs 1.3722 µs]
                        change: [-28.923% -28.688% -28.516%] (p = 0.00 < 0.05)
                        Performance has improved.
```

TODO: I need to improve the name of the function `horner_duble_with_cheese`.

Maybe this is a silly optimization and should not be merged. If you think so, just close this PR.